### PR TITLE
make table compact concurrent

### DIFF
--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -386,6 +386,17 @@ impl CompactionTask {
     pub fn inputs(&self) -> &[CompactionInputFiles] {
         &self.inputs
     }
+
+    #[inline]
+    pub fn contains_min_level(&self) -> bool {
+        for input in &self.inputs {
+            if input.level.is_min() {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 pub struct CompactionTaskBuilder {


### PR DESCRIPTION
## Rationale
When table with many small l0 sst, it will hurt query perf, so we should support compact same table concurrently.

## Detailed Changes
- Reschdule another compact req before do compact.

## Test Plan
WIP

