### PR TITLE
feat: avoid flush when drop table

### DIFF
--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -368,7 +368,6 @@ impl Instance {
         let dropper = Dropper {
             space,
             space_store: self.space_store.clone(),
-            flusher: self.make_flusher(),
         };
 
         dropper.drop(request).await

--- a/analytic_engine/src/memtable/skiplist/mod.rs
+++ b/analytic_engine/src/memtable/skiplist/mod.rs
@@ -49,7 +49,7 @@ struct Metrics {
 }
 
 /// MemTable implementation based on skiplist
-pub struct SkiplistMemTable<A: Arena<Stats = BasicStats> + Clone> {
+pub struct SkiplistMemTable<A> {
     /// Schema of this memtable, is immutable.
     schema: Schema,
     skiplist: Skiplist<BytewiseComparator, A>,
@@ -60,6 +60,16 @@ pub struct SkiplistMemTable<A: Arena<Stats = BasicStats> + Clone> {
     metrics: Metrics,
     min_time: AtomicI64,
     max_time: AtomicI64,
+}
+
+impl<A> Drop for SkiplistMemTable<A> {
+    fn drop(&mut self) {
+        logger::debug!(
+            "Drop memtable, last_seq:{}, schema:{:?}",
+            self.last_sequence.load(atomic::Ordering::Relaxed),
+            self.schema
+        );
+    }
 }
 
 impl<A: Arena<Stats = BasicStats> + Clone> SkiplistMemTable<A> {

--- a/components/skiplist/src/list.rs
+++ b/components/skiplist/src/list.rs
@@ -211,7 +211,7 @@ impl Node {
     }
 }
 
-struct SkiplistCore<A: Arena<Stats = BasicStats>> {
+struct SkiplistCore<A> {
     height: AtomicUsize,
     head: NonNull<Node>,
     arena: A,
@@ -220,7 +220,7 @@ struct SkiplistCore<A: Arena<Stats = BasicStats>> {
 /// FIXME(yingwen): Modify the skiplist to support arena that supports growth,
 /// otherwise it is hard to avoid memory usage not out of the arena capacity
 #[derive(Clone)]
-pub struct Skiplist<C, A: Arena<Stats = BasicStats> + Clone> {
+pub struct Skiplist<C, A> {
     core: Arc<SkiplistCore<A>>,
     c: C,
 }


### PR DESCRIPTION
## Rationale
When drop a table, flush is unnecessary, and this cause the drop take a long time.

## Detailed Changes
Mark WAL as deleted directly when drop table.

## Test Plan
Manually

